### PR TITLE
Support override of image url when when running tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ Run unit tests. To run quick tests use: ./gradlew -Dclcip=CLC_IP_ADDR test \
     testLogging.showStandardStreams =
         Boolean.valueOf( System.getProperty( 'testsToConsole', 'true' ) )
 
-    [ 'clcip', 'user', 'password', 'endpoints', 'inifile', 'cache' ].each{
+    [ 'clcip', 'user', 'password', 'endpoints', 'inifile', 'cache', 'n4j.image.hvm-url' ].each{
         if ( System.getProperty( it ) ) systemProperty it, System.getProperty( it )
     }
 


### PR DESCRIPTION
This pull request allows the image override system property to be set when running tests, e.g.

```
export N4J_OPTS='-Dn4j.image.hvm-url=http://my.image.mirror.host/and/path/CentOS-7-x86_64-GenericCloud.raw.tar.gz' 
./n4j.sh my.clc.host TestEC2ImageRegistration
```