### PR TITLE
Autoscaling multiple availability zone test account

### DIFF
--- a/src/main/java/com/eucalyptus/tests/awssdk/TestAutoScalingDescribeInstances.java
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestAutoScalingDescribeInstances.java
@@ -21,6 +21,7 @@
 package com.eucalyptus.tests.awssdk;
 
 import com.amazonaws.services.autoscaling.model.*;
+import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
 import com.google.common.collect.Sets;
 import org.junit.Test;
@@ -156,7 +157,10 @@ public class TestAutoScalingDescribeInstances {
       while (!terminated
           && (System.currentTimeMillis() - terminateStartTime) < terminateTimeout) {
         Thread.sleep(5000);
-        final List<String> instanceIds = (List<String>) getInstancesForGroupWithStatus(groupName, Sets.newHashSet( "running", "shutting-down" ), true);
+        final List<String> instanceIds = (List<String>) getInstancesForGroup(
+            groupName,
+            Sets.newHashSet( "running", "shutting-down" ),
+            Instance::getInstanceId );
         terminated = instanceIds.size() == 0;
       }
       assertThat(terminated,

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestAutoScalingLaunchAndTerminate.java
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestAutoScalingLaunchAndTerminate.java
@@ -21,6 +21,7 @@
 package com.eucalyptus.tests.awssdk;
 
 import com.amazonaws.services.autoscaling.model.*;
+import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
 import com.google.common.collect.Sets;
 import org.junit.Test;
@@ -81,7 +82,8 @@ public class TestAutoScalingLaunchAndTerminate {
       cleanupTasks.add(new Runnable() {
         @Override
         public void run() {
-          final List<String> instanceIds = (List<String>) getInstancesForGroupWithStatus(groupName, Collections.emptySet(  ), true);
+          final List<String> instanceIds =
+              (List<String>) getInstancesForGroup(groupName, Collections.emptySet(  ), Instance::getInstanceId);
           print("Terminating instances: " + instanceIds);
           ec2.terminateInstances(new TerminateInstancesRequest()
               .withInstanceIds(instanceIds));
@@ -122,7 +124,10 @@ public class TestAutoScalingLaunchAndTerminate {
       while (!terminated
           && (System.currentTimeMillis() - terminateStartTime) < terminateTimeout) {
         Thread.sleep(5000);
-        final List<String> instanceIds = (List<String>) getInstancesForGroupWithStatus(groupName, Sets.newHashSet( "running", "shutting-down" ), true);
+        final List<String> instanceIds = (List<String>) getInstancesForGroup(
+            groupName,
+            Sets.newHashSet( "running", "shutting-down" ),
+            Instance::getInstanceId);
         terminated = instanceIds.size() == 0;
       }
       assertThat(terminated,

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestAutoScalingMultipleAvailabilityZones.java
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestAutoScalingMultipleAvailabilityZones.java
@@ -20,10 +20,16 @@
 
 package com.eucalyptus.tests.awssdk;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.internal.StaticCredentialsProvider;
+import com.amazonaws.services.autoscaling.AmazonAutoScaling;
 import com.amazonaws.services.autoscaling.model.CreateAutoScalingGroupRequest;
 import com.amazonaws.services.autoscaling.model.SetDesiredCapacityRequest;
+import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.model.DescribeAvailabilityZonesResult;
 import com.amazonaws.services.ec2.model.Instance;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -31,8 +37,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
-import static com.eucalyptus.tests.awssdk.N4j.*;
 
 /**
  * This application tests auto scaling with multiple availability zones.
@@ -43,19 +47,44 @@ import static com.eucalyptus.tests.awssdk.N4j.*;
  */
 public class TestAutoScalingMultipleAvailabilityZones {
 
-	@SuppressWarnings("unchecked")
+	private static String testAcct;
+	private static AWSCredentialsProvider testAcctAdminCredentials;
+	private static AmazonEC2 ec2;
+	private static AmazonAutoScaling as;
+
+	@BeforeClass
+	public static void init( ) throws Exception {
+		N4j.getCloudInfo( );
+		testAcct = N4j.NAME_PREFIX + "autoscaling-multiaz";
+		N4j.createAccount( testAcct );
+		testAcctAdminCredentials = new StaticCredentialsProvider( N4j.getUserCreds( testAcct, "admin" ) );
+		ec2 = N4j.getEc2Client(
+				testAcctAdminCredentials.getCredentials().getAWSAccessKeyId( ),
+				testAcctAdminCredentials.getCredentials().getAWSSecretKey( ),
+				N4j.EC2_ENDPOINT );
+		as = N4j.getAutoScalingClient(
+				testAcctAdminCredentials.getCredentials().getAWSAccessKeyId( ),
+				testAcctAdminCredentials.getCredentials().getAWSSecretKey( ),
+				N4j.AS_ENDPOINT );
+	}
+
+	@AfterClass
+	public static void cleanup( ) {
+		if ( as != null ) as.shutdown( );
+		if ( ec2 != null ) ec2.shutdown( );
+		N4j.deleteAccount( testAcct );
+	}
+
+  @SuppressWarnings("unchecked")
 	@Test
 	public void AutoScalingMultipleAvailabilityZonesTest() throws Exception {
-        testInfo(this.getClass().getSimpleName());
-        getCloudInfo();
-
 		// Find an AZ to use
 		final DescribeAvailabilityZonesResult azResult = ec2
 				.describeAvailabilityZones();
 
         // If only 1 AZ then do not run test but pass w/ a message
         if (azResult.getAvailabilityZones().size() < 2) {
-            print("Test Skipped: Multiple Availability Zones Required");
+            N4j.print("Test Skipped: Multiple Availability Zones Required");
             return;
         }
 
@@ -63,30 +92,30 @@ public class TestAutoScalingMultipleAvailabilityZones {
 				.getZoneName();
 		final String availabilityZone2 = azResult.getAvailabilityZones().get(1)
 				.getZoneName();
-		print("Using availability zones: "
+    N4j.print("Using availability zones: "
 				+ Arrays.asList(availabilityZone1, availabilityZone2));
 
 		// End discovery, start test
-		final String namePrefix = eucaUUID() + "-";
-		print("Using resource prefix for test: " + namePrefix);
+		final String namePrefix = N4j.eucaUUID() + "-";
+    N4j.print("Using resource prefix for test: " + namePrefix);
 
 		final List<Runnable> cleanupTasks = new ArrayList<Runnable>();
 		try {
 			// Create launch configuration
             final String launchConfig = namePrefix + "MultipleZones";
-			print("Creating launch configuration: " +  launchConfig);
-            createLaunchConfig(launchConfig,IMAGE_ID,INSTANCE_TYPE,null,null,null,null,null,null,null,null);
+      N4j.print("Creating launch configuration: " +  launchConfig);
+      N4j.createLaunchConfig(launchConfig,N4j.IMAGE_ID,N4j.INSTANCE_TYPE,null,null,null,null,null,null,null,null);
 			cleanupTasks.add(new Runnable() {
 				@Override
 				public void run() {
-					print("Deleting launch configuration: " + launchConfig);
-					deleteLaunchConfig(launchConfig);
+          N4j.print("Deleting launch configuration: " + launchConfig);
+          N4j.deleteLaunchConfig(launchConfig);
 				}
 			});
 
 			// Create scaling group
 			final String groupName = namePrefix + "MultipleZones";
-			print("Creating auto scaling group: " + groupName);
+      N4j.print("Creating auto scaling group: " + groupName);
 			as.createAutoScalingGroup(new CreateAutoScalingGroupRequest()
 					.withAutoScalingGroupName(groupName)
 					.withLaunchConfigurationName(launchConfig)
@@ -99,58 +128,58 @@ public class TestAutoScalingMultipleAvailabilityZones {
 			cleanupTasks.add(new Runnable() {
 				@Override
 				public void run() {
-					print("Deleting group: " + groupName);
-					deleteAutoScalingGroup(groupName, true);
+          N4j.print("Deleting group: " + groupName);
+          N4j.deleteAutoScalingGroup(groupName, true);
 				}
 			});
 
 			// Wait for instances to launch
-			print("Waiting for 2 instances to launch");
+      N4j.print("Waiting for 2 instances to launch");
 			final long timeout = TimeUnit.MINUTES.toMillis(15);
-			List<Instance> instances = (List<Instance>) waitForInstances(timeout, 2, groupName, false);
+			List<Instance> instances = (List<Instance>) N4j.waitForInstances(timeout, 2, groupName, false);
 			assertBalanced(instances, availabilityZone1, availabilityZone2);
 
 			// Update group desired capacity and wait for instances to launch
-			print("Setting desired capacity to 4 for group: " + groupName);
+      N4j.print("Setting desired capacity to 4 for group: " + groupName);
 			as.setDesiredCapacity(new SetDesiredCapacityRequest()
 					.withAutoScalingGroupName(groupName).withDesiredCapacity(4));
 
 			// Wait for instances to launch
-			print("Waiting for 2 instances to launch");
-			instances = (List<Instance>) waitForInstances(timeout, 4, groupName, false);
+      N4j.print("Waiting for 2 instances to launch");
+			instances = (List<Instance>) N4j.waitForInstances(timeout, 4, groupName, false);
 			assertBalanced(instances, availabilityZone1, availabilityZone2);
 
 			// Update group desired capacity and wait for instances to launch
-			print("Setting desired capacity to 2 for group: " + groupName);
+      N4j.print("Setting desired capacity to 2 for group: " + groupName);
 			as.setDesiredCapacity(new SetDesiredCapacityRequest()
 					.withAutoScalingGroupName(groupName).withDesiredCapacity(2));
 
 			// Wait for instances to terminate
-			print("Waiting for 2 instances to terminate");
-			instances = (List<Instance>) waitForInstances(timeout, 2, groupName, false);
+      N4j.print("Waiting for 2 instances to terminate");
+			instances = (List<Instance>) N4j.waitForInstances(timeout, 2, groupName, false);
 			assertBalanced(instances, availabilityZone1, availabilityZone2);
 
 			// Update group desired capacity and wait for instances to terminate
-			print("Setting desired capacity to 0 for group: " + groupName);
+      N4j.print("Setting desired capacity to 0 for group: " + groupName);
 			as.setDesiredCapacity(new SetDesiredCapacityRequest()
 					.withAutoScalingGroupName(groupName).withDesiredCapacity(0));
 
 			// Wait for instances to terminate
-			print("Waiting for 2 instances to terminate");
-			waitForInstances(timeout, 0, groupName, false);
+      N4j.print("Waiting for 2 instances to terminate");
+      N4j.waitForInstances(timeout, 0, groupName, false);
 
 			// Update group desired capacity and wait for instances to launch
-			print("Setting desired capacity to 4 for group: " + groupName);
+      N4j.print("Setting desired capacity to 4 for group: " + groupName);
 			as.setDesiredCapacity(new SetDesiredCapacityRequest()
 					.withAutoScalingGroupName(groupName).withDesiredCapacity(4));
 
 			// Wait for instances to launch
-			print("Waiting for 4 instances to launch");
-			instances = (List<Instance>) waitForInstances(timeout, 4,
+      N4j.print("Waiting for 4 instances to launch");
+			instances = (List<Instance>) N4j.waitForInstances(timeout, 4,
 					groupName, false);
 			assertBalanced(instances, availabilityZone1, availabilityZone2);
 
-			print("Test complete");
+      N4j.print("Test complete");
 		} finally {
 			// Attempt to clean up anything we created
 			Collections.reverse(cleanupTasks);
@@ -169,7 +198,7 @@ public class TestAutoScalingMultipleAvailabilityZones {
 		final int zone1Count = countZoneInstances(instances, zone1);
 		final int zone2Count = countZoneInstances(instances, zone2);
 
-		assertThat(zone1Count + zone2Count == instances.size()
+    N4j.assertThat(zone1Count + zone2Count == instances.size()
 				&& zone1Count == zone2Count, "Zones are not balanced " + zone1
 				+ "=" + zone1Count + " / " + zone2 + "=" + zone2Count);
 	}

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestAutoScalingSuspendAndResumeProcesses.java
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestAutoScalingSuspendAndResumeProcesses.java
@@ -21,6 +21,7 @@ package com.eucalyptus.tests.awssdk;
 
 import com.amazonaws.services.autoscaling.AmazonAutoScaling;
 import com.amazonaws.services.autoscaling.model.*;
+import com.amazonaws.services.ec2.model.Instance;
 import com.google.common.collect.Sets;
 import org.junit.Test;
 
@@ -170,7 +171,10 @@ public class TestAutoScalingSuspendAndResumeProcesses {
             boolean terminated = false;
             while (!terminated && (System.currentTimeMillis() - terminateStartTime) < terminateTimeout) {
                 Thread.sleep(5000);
-                final List<String> instanceIds = (List<String>) getInstancesForGroupWithStatus(groupName, Sets.newHashSet( "running", "shutting-down" ), true);
+                final List<String> instanceIds = (List<String>) getInstancesForGroup(
+                    groupName,
+                    Sets.newHashSet( "running", "shutting-down" ),
+                    Instance::getInstanceId );
                 terminated = instanceIds.size() == 0;
             }
             assertThat(terminated, "Instance was not terminated within the expected timeout");


### PR DESCRIPTION
Autoscaling multiple availability zone test now creates an account for test use so existing ec2 instances do not cause spurious test failures.