### PR TITLE
Test should not use hardcoded availability zone

### DIFF
--- a/src/main/resources/com/eucalyptus/tests/awssdk/cf_template_instance_volumes.json
+++ b/src/main/resources/com/eucalyptus/tests/awssdk/cf_template_instance_volumes.json
@@ -10,7 +10,7 @@
     "Zone": {
       "Description": "The zone to launch instances in",
       "Type": "String",
-      "Default": "one"
+      "Default": "auto-select"
     },
     "KeyName": {
       "Description": "Name of an existing EC2 KeyPair to enable SSH access to the instances",
@@ -23,6 +23,9 @@
       "Default": "m1.small",
       "ConstraintDescription": "must be a valid EC2 instance type."
     }
+  },
+  "Conditions" : {
+    "UseZoneParameter" : {"Fn::Not": [{"Fn::Equals" : [{"Ref" : "Zone"}, "auto-select"]}]}
   },
   "Resources": {
     "default": {
@@ -43,18 +46,22 @@
       "Type": "AWS::EC2::Volume",
       "Properties": {
         "Size": "1",
-        "AvailabilityZone": {
-          "Ref": "Zone"
-        }
+        "AvailabilityZone": { "Fn::If" : [
+          "UseZoneParameter",
+          { "Ref" : "Zone" },
+          { "Fn::Select" : [ "0", { "Fn::GetAZs" : { "Ref" : "AWS::Region" } } ] }
+        ] }
       }
     },
     "volume02": {
       "Type": "AWS::EC2::Volume",
       "Properties": {
         "Size": "1",
-        "AvailabilityZone": {
-          "Ref": "Zone"
-        }
+        "AvailabilityZone": { "Fn::If" : [
+          "UseZoneParameter",
+          { "Ref" : "Zone" },
+          { "Fn::Select" : [ "0", { "Fn::GetAZs" : { "Ref" : "AWS::Region" } } ] }
+        ] }
       },
       "DependsOn" : "volume01"
     },
@@ -62,9 +69,11 @@
       "Type": "AWS::EC2::Volume",
       "Properties": {
         "Size": "1",
-        "AvailabilityZone": {
-          "Ref": "Zone"
-        }
+        "AvailabilityZone": { "Fn::If" : [
+          "UseZoneParameter",
+          { "Ref" : "Zone" },
+          { "Fn::Select" : [ "0", { "Fn::GetAZs" : { "Ref" : "AWS::Region" } } ] }
+        ] }
       },
       "DependsOn" : "volume02"
     },
@@ -72,16 +81,22 @@
       "Type": "AWS::EC2::Volume",
       "Properties": {
         "Size": "1",
-        "AvailabilityZone": {
-          "Ref": "Zone"
-        }
+        "AvailabilityZone": { "Fn::If" : [
+          "UseZoneParameter",
+          { "Ref" : "Zone" },
+          { "Fn::Select" : [ "0", { "Fn::GetAZs" : { "Ref" : "AWS::Region" } } ] }
+        ] }
       },
       "DependsOn" : "volume03"
     },
     "instance" : {
       "Type" : "AWS::EC2::Instance",
       "Properties" : {
-        "AvailabilityZone" : { "Ref" : "Zone" },
+        "AvailabilityZone" : { "Fn::If" : [
+          "UseZoneParameter",
+          { "Ref" : "Zone" },
+          { "Fn::Select" : [ "0", { "Fn::GetAZs" : { "Ref" : "AWS::Region" } } ] }
+        ] },
         "ImageId" : { "Ref" : "ImageId" },
         "KeyName" : { "Ref": "KeyName" }
       }


### PR DESCRIPTION
CloudFormation test for instance volumes now uses first zone from region if not otherwise specified. This fixes the test on clouds that do not have an availability zone `one`.