### PR TITLE
Unit tests use configured endpoints where possible

### DIFF
--- a/src/main/java/com/eucalyptus/tests/awssdk/N4j.java
+++ b/src/main/java/com/eucalyptus/tests/awssdk/N4j.java
@@ -205,6 +205,10 @@ public class N4j {
         print("CLC IP: " + clcip);
         SftpATTRS attrs = null;
 
+        if ( clcip == null || clcip.isEmpty( ) ) {
+            return;
+        }
+
         try {
             JSch jsch = new JSch();
             Session session = jsch.getSession(user, clcip, 22);

--- a/src/main/java/com/eucalyptus/tests/awssdk/N4j.java
+++ b/src/main/java/com/eucalyptus/tests/awssdk/N4j.java
@@ -189,11 +189,7 @@ public class N4j {
 	}
 
     public static void minimalInit() throws Exception {
-        getAdminCreds(CLC_IP, USER, PASSWORD);
-        EC2_ENDPOINT = getAttribute(LOCAL_INI_FILE, "ec2-url");
-        print("HOST = " + CLC_IP);
-        SECRET_KEY = getAttribute(LOCAL_INI_FILE, "secret-key");
-        ACCESS_KEY = getAttribute(LOCAL_INI_FILE, "key-id");
+        initEndpoints( );
         print("Cloud Discovery Complete");
     }
 

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestAutoScalingEC2InstanceTerminationProtection.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestAutoScalingEC2InstanceTerminationProtection.groovy
@@ -23,7 +23,6 @@ import com.amazonaws.services.ec2.model.TerminateInstancesRequest
 import org.junit.Test
 
 import static N4j.ACCESS_KEY
-import static N4j.CLC_IP
 import static N4j.SECRET_KEY
 import static N4j.minimalInit
 
@@ -37,7 +36,6 @@ import static N4j.minimalInit
  */
 class TestAutoScalingEC2InstanceTerminationProtection {
 
-  private final String host
   private final AWSCredentialsProvider credentials
 
   public static void main( String[] args ) throws Exception {
@@ -46,25 +44,18 @@ class TestAutoScalingEC2InstanceTerminationProtection {
 
   public TestAutoScalingEC2InstanceTerminationProtection( ){
     minimalInit( )
-    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
-  }
-
-  private String cloudUri( String servicePath ) {
-    URI.create( "http://" + host + ":8773/" )
-        .resolve( servicePath )
-        .toString()
   }
 
   private AmazonAutoScaling getAutoScalingClient( final AWSCredentialsProvider credentials ) {
     final AmazonAutoScaling auto = new AmazonAutoScalingClient( credentials )
-    auto.endpoint = cloudUri( '/services/AutoScaling' )
+    auto.endpoint = N4j.AS_ENDPOINT
     auto
   }
 
   private AmazonEC2Client getEC2Client( final AWSCredentialsProvider credentials ) {
     final AmazonEC2Client ec2 = new AmazonEC2Client( credentials )
-    ec2.endpoint = cloudUri( '/services/compute' )
+    ec2.endpoint = N4j.EC2_ENDPOINT
     ec2
   }
 

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestAutoScalingEC2VPC.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestAutoScalingEC2VPC.groovy
@@ -29,7 +29,6 @@ import com.amazonaws.services.ec2.model.Filter
 import org.junit.Test;
 
 import static N4j.ACCESS_KEY
-import static N4j.CLC_IP
 import static N4j.SECRET_KEY
 import static N4j.minimalInit
 
@@ -42,7 +41,6 @@ import static N4j.minimalInit
  */
 class TestAutoScalingEC2VPC {
 
-  private final String host;
   private final AWSCredentialsProvider credentials
 
   public static void main( String[] args ) throws Exception {
@@ -52,25 +50,18 @@ class TestAutoScalingEC2VPC {
 
   public TestAutoScalingEC2VPC() {
     minimalInit()
-    this.host = CLC_IP;
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
-  }
-
-  private String cloudUri( String servicePath ) {
-    URI.create( "http://" + host + ":8773/" )
-            .resolve( servicePath )
-            .toString()
   }
 
   private AmazonAutoScaling getAutoScalingClient( ) {
     final AmazonAutoScaling asc = new AmazonAutoScalingClient( credentials )
-    asc.setEndpoint( cloudUri( "/services/AutoScaling/" ) )
+    asc.setEndpoint( N4j.AS_ENDPOINT )
     asc
   }
 
   private AmazonEC2 getEc2Client( ) {
     final AmazonEC2 ec2 = new AmazonEC2Client( credentials )
-    ec2.setEndpoint( cloudUri( "/services/compute/" ) )
+    ec2.setEndpoint( N4j.EC2_ENDPOINT )
     ec2
   }
 

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestEC2VPCDefaultVPC.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestEC2VPCDefaultVPC.groovy
@@ -18,8 +18,6 @@ import com.github.sjones4.youcan.youprop.model.ModifyPropertyValueRequest
 import org.junit.Test;
 
 import static N4j.minimalInit;
-import static N4j.CLC_IP;
-import static N4j.EC2_ENDPOINT;
 import static N4j.ACCESS_KEY;
 import static N4j.SECRET_KEY;
 
@@ -32,7 +30,6 @@ import static N4j.SECRET_KEY;
  */
 class TestEC2VPCDefaultVPC {
 
-  private final String host
   private final AWSCredentialsProvider credentials
 
   public static void main( String[] args ) throws Exception {
@@ -41,31 +38,24 @@ class TestEC2VPCDefaultVPC {
 
   public TestEC2VPCDefaultVPC(){
     minimalInit()
-    this.host=CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
-  }
-
-  private String cloudUri( String servicePath ) {
-    URI.create( "http://" + host + ":8773/" )
-            .resolve( servicePath )
-            .toString()
   }
 
   private AmazonEC2Client getEC2Client( final AWSCredentialsProvider credentials ) {
     final AmazonEC2Client ec2 = new AmazonEC2Client( credentials )
-    ec2.setEndpoint( EC2_ENDPOINT )
+    ec2.setEndpoint( N4j.EC2_ENDPOINT )
     ec2
   }
 
   private YouProp getYouPropClient( final AWSCredentialsProvider credentials ) {
     final YouProp youProp = new YouPropClient( credentials )
-    youProp.setEndpoint( cloudUri( "/services/Properties/" ) )
+    youProp.setEndpoint( N4j.PROPERTIES_ENDPOINT )
     youProp
   }
 
   private YouAreClient getYouAreClient( final AWSCredentialsProvider credentials ) {
     final YouAreClient euare = new YouAreClient( credentials )
-    euare.setEndpoint( cloudUri( "/services/Euare" ) )
+    euare.setEndpoint( N4j.IAM_ENDPOINT )
     euare
   }
 
@@ -77,7 +67,7 @@ class TestEC2VPCDefaultVPC {
         request.addParameter( "DelegateAccount", asAccount )
       }
     } );
-    euare.setEndpoint( cloudUri( "/services/Euare" ) )
+    euare.setEndpoint( N4j.IAM_ENDPOINT )
     euare;
   }
 

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestEC2VPCQuotasLimits.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestEC2VPCQuotasLimits.groovy
@@ -22,8 +22,6 @@ import com.github.sjones4.youcan.youprop.model.ModifyPropertyValueRequest
 import org.junit.Test;
 
 import static N4j.ACCESS_KEY
-import static N4j.EC2_ENDPOINT
-import static N4j.CLC_IP
 import static N4j.SECRET_KEY
 import static N4j.minimalInit
 
@@ -36,7 +34,6 @@ import static N4j.minimalInit
  */
 class TestEC2VPCQuotasLimits {
 
-  private final String host
   private final AWSCredentialsProvider credentials
 
   public static void main( String[] args ) throws Exception {
@@ -45,31 +42,24 @@ class TestEC2VPCQuotasLimits {
 
   public TestEC2VPCQuotasLimits() {
     minimalInit()
-    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
-  }
-
-  private String cloudUri( String servicePath ) {
-    URI.create( "http://" + host + ":8773/" )
-        .resolve( servicePath )
-        .toString()
   }
 
   private AmazonEC2 getEC2Client( final AWSCredentialsProvider credentials ) {
     final AmazonEC2 ec2 = new AmazonEC2Client( credentials )
-    ec2.setEndpoint( EC2_ENDPOINT )
+    ec2.setEndpoint( N4j.EC2_ENDPOINT )
     ec2
   }
 
   private YouAreClient getYouAreClient( final AWSCredentialsProvider credentials  ) {
     final YouAreClient euare = new YouAreClient( credentials )
-    euare.setEndpoint( cloudUri( "/services/Euare/" ) )
+    euare.setEndpoint( N4j.IAM_ENDPOINT )
     euare
   }
 
   private YouProp getYouPropClient( final AWSCredentialsProvider credentials ) {
     final YouProp youProp = new YouPropClient( credentials )
-    youProp.setEndpoint( cloudUri( "/services/Properties/" ) )
+    youProp.setEndpoint( N4j.PROPERTIES_ENDPOINT )
     youProp
   }
 

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestEC2VPCResourceConditionPolicy.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestEC2VPCResourceConditionPolicy.groovy
@@ -19,8 +19,6 @@ import com.github.sjones4.youcan.youare.model.DeleteAccountRequest
 import org.junit.Test;
 
 import static N4j.ACCESS_KEY
-import static N4j.CLC_IP
-import static N4j.EC2_ENDPOINT
 import static N4j.SECRET_KEY
 import static N4j.minimalInit
 
@@ -33,7 +31,6 @@ import static N4j.minimalInit
  */
 class TestEC2VPCResourceConditionPolicy {
 
-  private final String host;
   private final AWSCredentialsProvider credentials
 
   public static void main( String[] args ) throws Exception {
@@ -42,25 +39,18 @@ class TestEC2VPCResourceConditionPolicy {
 
   public TestEC2VPCResourceConditionPolicy() {
     minimalInit()
-    this.host=CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
-  }
-
-  private String cloudUri( String servicePath ) {
-    URI.create( "http://" + host + ":8773/" )
-        .resolve( servicePath )
-        .toString()
   }
 
   private AmazonEC2 getEC2Client( final AWSCredentialsProvider credentials ) {
     final AmazonEC2 ec2 = new AmazonEC2Client( credentials )
-    ec2.setEndpoint( EC2_ENDPOINT )
+    ec2.setEndpoint( N4j.EC2_ENDPOINT )
     ec2
   }
 
   private YouAreClient getYouAreClient( final AWSCredentialsProvider credentials  ) {
     final YouAreClient euare = new YouAreClient( credentials )
-    euare.setEndpoint( cloudUri( "/services/Euare/" ) )
+    euare.setEndpoint( N4j.IAM_ENDPOINT )
     euare
   }
 

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestEC2VPCSecurityGroupEgressRules.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestEC2VPCSecurityGroupEgressRules.groovy
@@ -11,7 +11,6 @@ import com.amazonaws.services.ec2.model.*
 import org.junit.Test;
 
 import static N4j.ACCESS_KEY
-import static N4j.CLC_IP
 import static N4j.SECRET_KEY
 import static N4j.minimalInit
 
@@ -25,7 +24,6 @@ import static N4j.minimalInit
  */
 class TestEC2VPCSecurityGroupEgressRules {
 
-    private final String host;
     private final AWSCredentialsProvider credentials
 
 
@@ -35,19 +33,12 @@ class TestEC2VPCSecurityGroupEgressRules {
 
     public TestEC2VPCSecurityGroupEgressRules() {
         minimalInit()
-        this.host= CLC_IP
         this.credentials = new StaticCredentialsProvider(new BasicAWSCredentials(ACCESS_KEY, SECRET_KEY))
-    }
-
-    private String cloudUri(String servicePath) {
-        URI.create("http://" + host + ":8773/")
-                .resolve(servicePath)
-                .toString()
     }
 
     private AmazonEC2 getEC2Client(final AWSCredentialsProvider credentials) {
         final AmazonEC2 ec2 = new AmazonEC2Client(credentials)
-        ec2.setEndpoint(cloudUri("/services/compute"))
+        ec2.setEndpoint( N4j.EC2_ENDPOINT )
         ec2
     }
 

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestEC2VPCSecurityGroups.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestEC2VPCSecurityGroups.groovy
@@ -10,7 +10,6 @@ import com.amazonaws.services.ec2.model.*
 import org.junit.Test;
 
 import static N4j.ACCESS_KEY
-import static N4j.CLC_IP
 import static N4j.SECRET_KEY
 import static N4j.minimalInit
 
@@ -24,7 +23,6 @@ import static N4j.minimalInit
  */
 class TestEC2VPCSecurityGroups {
 
-    private final String host;
     private final AWSCredentialsProvider credentials
 
 
@@ -35,19 +33,12 @@ class TestEC2VPCSecurityGroups {
 
     public TestEC2VPCSecurityGroups() {
         minimalInit()
-        this.host=CLC_IP
         this.credentials = new StaticCredentialsProvider(new BasicAWSCredentials(ACCESS_KEY, SECRET_KEY))
-    }
-
-    private String cloudUri(String servicePath) {
-        URI.create("http://" + host + ":8773/")
-                .resolve(servicePath)
-                .toString()
     }
 
     private AmazonEC2 getEC2Client(final AWSCredentialsProvider credentials) {
         final AmazonEC2 ec2 = new AmazonEC2Client(credentials)
-        ec2.setEndpoint(cloudUri("/services/compute"))
+        ec2.setEndpoint( N4j.EC2_ENDPOINT )
         ec2
     }
 

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestEC2VPCSecurityGroupsInstancesAttributes.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestEC2VPCSecurityGroupsInstancesAttributes.groovy
@@ -31,7 +31,6 @@ import com.amazonaws.services.ec2.model.*
 import org.junit.Test
 
 import static N4j.ACCESS_KEY
-import static N4j.CLC_IP
 import static N4j.SECRET_KEY
 import static N4j.minimalInit
 
@@ -47,7 +46,6 @@ import static N4j.minimalInit
  */
 class TestEC2VPCSecurityGroupsInstancesAttributes {
 
-  private final String host
   private final AWSCredentialsProvider credentials
   private final List<String> imageOwners
 
@@ -57,21 +55,14 @@ class TestEC2VPCSecurityGroupsInstancesAttributes {
 
   public TestEC2VPCSecurityGroupsInstancesAttributes() {
       minimalInit()
-      this.host=CLC_IP
       this.credentials = new StaticCredentialsProvider(new BasicAWSCredentials(ACCESS_KEY, SECRET_KEY))
       this.imageOwners = imageOwners
   }
 
-  private String cloudUri( String servicePath ) {
-    URI.create( "http://" + host + ":8773/" )
-        .resolve( servicePath )
-        .toString()
-  }
-
   private AmazonEC2 getEC2Client( final AWSCredentialsProvider credentials ) {
     final AmazonEC2 ec2 = new AmazonEC2Client( credentials )
-    if ( host ) {
-      ec2.setEndpoint( cloudUri("/services/compute") )
+    if ( N4j.EC2_ENDPOINT ) {
+      ec2.setEndpoint( N4j.EC2_ENDPOINT )
     } else {
       ec2.setRegion( com.amazonaws.regions.Region.getRegion( Regions.US_WEST_1 ) )
     }

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestELBAdministration.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestELBAdministration.groovy
@@ -28,14 +28,12 @@ import org.junit.Test
  * - deletion of an elb in another account using the dns name
  */
 class TestELBAdministration {
-  private final String host;
   private final AWSCredentialsProvider credentials;
   private final String testAcct
   private final AWSCredentialsProvider testAcctAdminCredentials
 
   public TestELBAdministration( ) {
     N4j.getCloudInfo( )
-    this.host = N4j.CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( N4j.ACCESS_KEY, N4j.SECRET_KEY ) )
 
     this.testAcct= "${N4j.NAME_PREFIX}test-acct"
@@ -48,20 +46,14 @@ class TestELBAdministration {
     N4j.deleteAccount(testAcct)
   }
 
-  private String cloudUri( String servicePath ) {
-    URI.create( "http://" + host + ":8773/" )
-        .resolve( servicePath )
-        .toString()
-  }
-
   private AmazonEC2 getEC2Client( final AWSCredentialsProvider credentials ) {
     final AmazonEC2 ec2 = new AmazonEC2Client( credentials )
-    ec2.setEndpoint( cloudUri( "/services/compute" ) )
+    ec2.setEndpoint( N4j.EC2_ENDPOINT )
     ec2
   }
   private AmazonElasticLoadBalancing getELBClient( final AWSCredentialsProvider credentials ) {
     final AmazonElasticLoadBalancing elb = new AmazonElasticLoadBalancingClient( credentials )
-    elb.setEndpoint( cloudUri( "/services/LoadBalancing" ) )
+    elb.setEndpoint( N4j.ELB_ENDPOINT )
     elb
   }
 

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestELBAttributes.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestELBAttributes.groovy
@@ -24,7 +24,6 @@ import com.amazonaws.services.elasticloadbalancing.model.ModifyLoadBalancerAttri
 
 import org.junit.Test
 
-import static N4j.CLC_IP;
 import static N4j.minimalInit;
 import static N4j.ACCESS_KEY;
 import static N4j.SECRET_KEY;
@@ -34,7 +33,6 @@ import static N4j.SECRET_KEY;
  */
 class TestELBAttributes {
 
-  private final String host;
   private final AWSCredentialsProvider credentials;
 
   public static void main( String[] args ) throws Exception {
@@ -43,20 +41,13 @@ class TestELBAttributes {
 
   public TestELBAttributes(){
     minimalInit()
-    this.host=CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
-  }
-
-  private String cloudUri( String servicePath ) {
-    URI.create( "http://" + host + ":8773/" )
-        .resolve( servicePath )
-        .toString()
   }
 
   private AmazonEC2 getEC2Client( final AWSCredentialsProvider credentials ) {
     final AmazonEC2 ec2 = new AmazonEC2Client( credentials )
-    if ( host ) {
-      ec2.setEndpoint( cloudUri( "/services/compute" ) )
+    if ( N4j.EC2_ENDPOINT ) {
+      ec2.setEndpoint( N4j.EC2_ENDPOINT )
     } else {
       ec2.setRegion(Region.getRegion( Regions.US_WEST_1 ) )
     }
@@ -65,8 +56,8 @@ class TestELBAttributes {
 
   private AmazonElasticLoadBalancing getELBClient( final AWSCredentialsProvider credentials ) {
     final AmazonElasticLoadBalancing elb = new AmazonElasticLoadBalancingClient( credentials )
-    if ( host ) {
-      elb.setEndpoint( cloudUri( "/services/LoadBalancing" ) )
+    if ( N4j.ELB_ENDPOINT ) {
+      elb.setEndpoint( N4j.ELB_ENDPOINT )
     } else {
       elb.setRegion(Region.getRegion( Regions.US_WEST_1 ) )
     }

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestELBDefaultVPC.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestELBDefaultVPC.groovy
@@ -26,7 +26,6 @@ import com.amazonaws.services.elasticloadbalancing.model.Listener
 import org.junit.Test;
 
 import static N4j.ACCESS_KEY
-import static N4j.CLC_IP
 import static N4j.SECRET_KEY
 import static N4j.minimalInit
 
@@ -35,7 +34,6 @@ import static N4j.minimalInit
  */
 class TestELBDefaultVPC {
 
-  private final String host;
   private final AWSCredentialsProvider credentials;
 
   public static void main( String[] args ) throws Exception {
@@ -44,20 +42,13 @@ class TestELBDefaultVPC {
 
   public TestELBDefaultVPC() {
     minimalInit()
-    this.host=CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
-  }
-
-  private String cloudUri( String servicePath ) {
-    URI.create( "http://" + host + ":8773/" )
-        .resolve( servicePath )
-        .toString()
   }
 
   private AmazonEC2 getEC2Client( final AWSCredentialsProvider credentials ) {
     final AmazonEC2 ec2 = new AmazonEC2Client( credentials )
-    if ( host ) {
-      ec2.setEndpoint( cloudUri( "/services/compute" ) )
+    if ( N4j.EC2_ENDPOINT ) {
+      ec2.setEndpoint( N4j.EC2_ENDPOINT )
     } else {
       ec2.setRegion(Region.getRegion( Regions.US_WEST_1 ) )
     }
@@ -66,8 +57,8 @@ class TestELBDefaultVPC {
 
   private AmazonElasticLoadBalancing getELBClient( final AWSCredentialsProvider credentials ) {
     final AmazonElasticLoadBalancing elb = new AmazonElasticLoadBalancingClient( credentials )
-    if ( host ) {
-      elb.setEndpoint( cloudUri( "/services/LoadBalancing" ) )
+    if ( N4j.ELB_ENDPOINT ) {
+      elb.setEndpoint( N4j.ELB_ENDPOINT )
     } else {
       elb.setRegion(Region.getRegion( Regions.US_WEST_1 ) )
     }

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestELBIAMResource.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestELBIAMResource.groovy
@@ -24,7 +24,6 @@ import com.amazonaws.services.identitymanagement.model.PutUserPolicyRequest
 import org.junit.Test;
 
 import static N4j.ACCESS_KEY
-import static N4j.CLC_IP
 import static N4j.SECRET_KEY
 import static N4j.minimalInit
 
@@ -37,7 +36,6 @@ import static N4j.minimalInit
  */
 class TestELBIAMResource {
 
-  private final String host
   private final AWSCredentialsProvider credentials
 
   public static void main( String[] args ) throws Exception {
@@ -46,26 +44,19 @@ class TestELBIAMResource {
 
   public TestELBIAMResource() {
     minimalInit()
-    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
-  }
-
-  private String cloudUri( String servicePath ) {
-    URI.create( "http://" + host + ":8773/" )
-        .resolve( servicePath )
-        .toString()
   }
 
   private AmazonEC2 getEC2Client( final AWSCredentialsProvider credentials ) {
     final AmazonEC2 ec2 = new AmazonEC2Client( credentials )
-    ec2.setEndpoint( cloudUri( "/services/compute" ) )
+    ec2.setEndpoint( N4j.EC2_ENDPOINT )
     ec2
   }
 
   private AmazonElasticLoadBalancing getELBClient( final AWSCredentialsProvider credentials ) {
     final AmazonElasticLoadBalancing elb = new AmazonElasticLoadBalancingClient( credentials )
-    if ( host ) {
-      elb.setEndpoint( cloudUri( "/services/LoadBalancing" ) )
+    if ( N4j.ELB_ENDPOINT ) {
+      elb.setEndpoint( N4j.ELB_ENDPOINT )
     } else {
       elb.setRegion(Region.getRegion( Regions.US_WEST_1 ) )
     }
@@ -74,8 +65,8 @@ class TestELBIAMResource {
 
   private AmazonIdentityManagement getIAMClient( final AWSCredentialsProvider credentials  ) {
     final AmazonIdentityManagementClient iam = new AmazonIdentityManagementClient( credentials )
-    if ( host ) {
-      iam.setEndpoint( cloudUri( "/services/Euare" ) )
+    if ( N4j.IAM_ENDPOINT ) {
+      iam.setEndpoint( N4j.IAM_ENDPOINT )
     }
     iam
   }

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestELBTagging.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestELBTagging.groovy
@@ -23,7 +23,6 @@ import com.amazonaws.services.elasticloadbalancing.model.TagKeyOnly
 import org.junit.Test;
 
 import static N4j.ACCESS_KEY
-import static N4j.CLC_IP
 import static N4j.SECRET_KEY
 import static N4j.minimalInit
 
@@ -32,7 +31,6 @@ import static N4j.minimalInit
  */
 class TestELBTagging {
 
-  private final String host;
   private final AWSCredentialsProvider credentials;
 
   public static void main( String[] args ) throws Exception {
@@ -41,20 +39,13 @@ class TestELBTagging {
 
   public TestELBTagging( ) {
     minimalInit()
-    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
-  }
-
-  private String cloudUri( String servicePath ) {
-    URI.create( "http://" + host + ":8773/" )
-        .resolve( servicePath )
-        .toString()
   }
 
   private AmazonEC2 getEC2Client( final AWSCredentialsProvider credentials ) {
     final AmazonEC2 ec2 = new AmazonEC2Client( credentials )
-    if ( host ) {
-      ec2.setEndpoint( cloudUri( "/services/compute" ) )
+    if ( N4j.EC2_ENDPOINT ) {
+      ec2.setEndpoint( N4j.EC2_ENDPOINT )
     } else {
       ec2.setRegion(Region.getRegion( Regions.US_WEST_1 ) )
     }
@@ -63,8 +54,8 @@ class TestELBTagging {
 
   private AmazonElasticLoadBalancing getELBClient( final AWSCredentialsProvider credentials ) {
     final AmazonElasticLoadBalancing elb = new AmazonElasticLoadBalancingClient( credentials )
-    if ( host ) {
-      elb.setEndpoint( cloudUri( "/services/LoadBalancing" ) )
+    if ( N4j.ELB_ENDPOINT ) {
+      elb.setEndpoint( N4j.ELB_ENDPOINT )
     } else {
       elb.setRegion(Region.getRegion( Regions.US_WEST_1 ) )
     }

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestELBVPC.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestELBVPC.groovy
@@ -27,7 +27,6 @@ import com.amazonaws.services.elasticloadbalancing.model.*
 import org.junit.Test;
 
 import static N4j.minimalInit;
-import static N4j.CLC_IP;
 import static N4j.ACCESS_KEY;
 import static N4j.SECRET_KEY;
 /**
@@ -35,7 +34,6 @@ import static N4j.SECRET_KEY;
  */
 class TestELBVPC {
 
-  private final String host;
   private final AWSCredentialsProvider credentials;
 
   public static void main( String[] args ) throws Exception {
@@ -44,20 +42,13 @@ class TestELBVPC {
 
   public TestELBVPC(  ) {
     minimalInit()
-    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
-  }
-
-  private String cloudUri( String servicePath ) {
-    URI.create( "http://" + host + ":8773/" )
-        .resolve( servicePath )
-        .toString()
   }
 
   private AmazonEC2 getEC2Client( final AWSCredentialsProvider credentials ) {
     final AmazonEC2 ec2 = new AmazonEC2Client( credentials )
-    if ( host ) {
-      ec2.setEndpoint( cloudUri( "/services/compute" ) )
+    if ( N4j.EC2_ENDPOINT ) {
+      ec2.setEndpoint( N4j.EC2_ENDPOINT )
     } else {
       ec2.setRegion(Region.getRegion( Regions.US_WEST_1 ) )
     }
@@ -66,8 +57,8 @@ class TestELBVPC {
 
   private AmazonElasticLoadBalancing getELBClient( final AWSCredentialsProvider credentials ) {
     final AmazonElasticLoadBalancing elb = new AmazonElasticLoadBalancingClient( credentials )
-    if ( host ) {
-      elb.setEndpoint( cloudUri( "/services/LoadBalancing" ) )
+    if ( N4j.ELB_ENDPOINT ) {
+      elb.setEndpoint( N4j.ELB_ENDPOINT )
     } else {
       elb.setRegion(Region.getRegion( Regions.US_WEST_1 ) )
     }

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeyLocationConstraint.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeyLocationConstraint.groovy
@@ -24,7 +24,6 @@ import org.junit.Assert
 import org.junit.Test
 
 import static N4j.minimalInit;
-import static N4j.CLC_IP;
 import static N4j.ACCESS_KEY;
 import static N4j.SECRET_KEY;
 
@@ -39,25 +38,17 @@ import static N4j.SECRET_KEY;
  */
 class TestS3IAMConditionKeyLocationConstraint {
 
-  private final String host
   private final AWSCredentialsProvider credentials
 
   TestS3IAMConditionKeyLocationConstraint( ) {
     minimalInit()
-    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
-  }
-
-  private String cloudUri( String host, String servicePath ) {
-    URI.create( "http://${host}:8773/" )
-        .resolve( servicePath )
-        .toString( )
   }
 
   private YouAreClient getYouAreClient( final AWSCredentialsProvider credentials  ) {
     final YouAreClient euare = new YouAreClient( credentials )
-    if ( host ) {
-      euare.setEndpoint( cloudUri( host, '/services/Euare' ) )
+    if ( N4j.IAM_ENDPOINT ) {
+      euare.setEndpoint( N4j.IAM_ENDPOINT )
     } else {
       euare.setRegion( Region.getRegion( Regions.US_EAST_1 ) )
     }
@@ -68,8 +59,8 @@ class TestS3IAMConditionKeyLocationConstraint {
     final ClientConfiguration clientConfiguration = new ClientConfiguration( )
     clientConfiguration.signerOverride = 'S3SignerType'
     final AmazonS3Client s3 = new AmazonS3Client( credentials, clientConfiguration )
-    if ( host ) {
-      s3.setEndpoint( cloudUri( host, '/services/objectstorage' ) )
+    if ( N4j.S3_ENDPOINT ) {
+      s3.setEndpoint( N4j.S3_ENDPOINT )
       s3.setS3ClientOptions( new S3ClientOptions( ).withPathStyleAccess( true ) )
     }
     return s3;
@@ -77,8 +68,8 @@ class TestS3IAMConditionKeyLocationConstraint {
 
   private AmazonEC2 getEC2Client( final AWSCredentialsProvider credentials ) {
     final AmazonEC2 ec2 = new AmazonEC2Client( credentials )
-    if ( host ) {
-      ec2.setEndpoint( cloudUri( host, '/services/compute' ) )
+    if ( N4j.EC2_ENDPOINT ) {
+      ec2.setEndpoint( N4j.EC2_ENDPOINT )
     }
     return ec2;
   }

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeyVersionId.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeyVersionId.groovy
@@ -27,7 +27,6 @@ import org.junit.Test
 import java.nio.charset.StandardCharsets
 
 import static N4j.minimalInit;
-import static N4j.CLC_IP;
 import static N4j.ACCESS_KEY;
 import static N4j.SECRET_KEY;
 
@@ -42,25 +41,17 @@ import static N4j.SECRET_KEY;
  */
 class TestS3IAMConditionKeyVersionId {
 
-  private final String host
   private final AWSCredentialsProvider credentials
 
   TestS3IAMConditionKeyVersionId( ) {
     minimalInit()
-    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
-  }
-
-  private String cloudUri( String host, String servicePath ) {
-    URI.create( "http://${host}:8773/" )
-        .resolve( servicePath )
-        .toString( )
   }
 
   private YouAreClient getYouAreClient( final AWSCredentialsProvider credentials  ) {
     final YouAreClient euare = new YouAreClient( credentials )
-    if ( host ) {
-      euare.setEndpoint( cloudUri( host, '/services/Euare' ) )
+    if ( N4j.IAM_ENDPOINT ) {
+      euare.setEndpoint( N4j.IAM_ENDPOINT )
     } else {
       euare.setRegion( Region.getRegion( Regions.US_EAST_1 ) )
     }
@@ -71,8 +62,8 @@ class TestS3IAMConditionKeyVersionId {
     final ClientConfiguration clientConfiguration = new ClientConfiguration( )
     clientConfiguration.signerOverride = 'S3SignerType'
     final AmazonS3Client s3 = new AmazonS3Client( credentials, clientConfiguration )
-    if ( host ) {
-      s3.setEndpoint( cloudUri( host, '/services/objectstorage' ) )
+    if ( N4j.S3_ENDPOINT ) {
+      s3.setEndpoint( N4j.S3_ENDPOINT )
       s3.setS3ClientOptions( new S3ClientOptions( ).withPathStyleAccess( true ) )
     }
     return s3;

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeysForAclsAndGrants.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeysForAclsAndGrants.groovy
@@ -31,7 +31,6 @@ import org.junit.Test
 import java.nio.charset.StandardCharsets
 
 import static N4j.minimalInit
-import static N4j.CLC_IP
 import static N4j.ACCESS_KEY
 import static N4j.SECRET_KEY
 
@@ -46,25 +45,17 @@ import static N4j.SECRET_KEY
  */
 class TestS3IAMConditionKeysForAclsAndGrants {
 
-  private final String host
   private final AWSCredentialsProvider credentials
 
   TestS3IAMConditionKeysForAclsAndGrants( ) {
     minimalInit()
-    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
-  }
-
-  private String cloudUri( String host, String servicePath ) {
-    URI.create( "http://${host}:8773/" )
-        .resolve( servicePath )
-        .toString( )
   }
 
   private YouAreClient getYouAreClient( final AWSCredentialsProvider credentials  ) {
     final YouAreClient euare = new YouAreClient( credentials )
-    if ( host ) {
-      euare.setEndpoint( cloudUri( host, '/services/Euare' ) )
+    if ( N4j.IAM_ENDPOINT ) {
+      euare.setEndpoint( N4j.IAM_ENDPOINT )
     } else {
       euare.setRegion( Region.getRegion( Regions.US_EAST_1 ) )
     }
@@ -75,8 +66,8 @@ class TestS3IAMConditionKeysForAclsAndGrants {
     final ClientConfiguration clientConfiguration = new ClientConfiguration( )
     clientConfiguration.signerOverride = 'S3SignerType'
     final AmazonS3Client s3 = new AmazonS3Client( credentials, clientConfiguration )
-    if ( host ) {
-      s3.setEndpoint( cloudUri( host, '/services/objectstorage' ) )
+    if ( N4j.S3_ENDPOINT ) {
+      s3.setEndpoint( N4j.S3_ENDPOINT )
       s3.setS3ClientOptions( new S3ClientOptions( ).withPathStyleAccess( true ) )
     }
     return s3;

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeysForPutObject.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeysForPutObject.groovy
@@ -24,7 +24,6 @@ import org.junit.Test
 import java.nio.charset.StandardCharsets
 
 import static N4j.minimalInit
-import static N4j.CLC_IP
 import static N4j.ACCESS_KEY
 import static N4j.SECRET_KEY
 
@@ -39,25 +38,17 @@ import static N4j.SECRET_KEY
  */
 class TestS3IAMConditionKeysForPutObject {
 
-  private final String host
   private final AWSCredentialsProvider credentials
 
   TestS3IAMConditionKeysForPutObject( ) {
     minimalInit()
-    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
-  }
-
-  private String cloudUri( String host, String servicePath ) {
-    URI.create( "http://${host}:8773/" )
-        .resolve( servicePath )
-        .toString( )
   }
 
   private YouAreClient getYouAreClient( final AWSCredentialsProvider credentials  ) {
     final YouAreClient euare = new YouAreClient( credentials )
-    if ( host ) {
-      euare.setEndpoint( cloudUri( host, '/services/Euare' ) )
+    if ( N4j.IAM_ENDPOINT ) {
+      euare.setEndpoint( N4j.IAM_ENDPOINT )
     } else {
       euare.setRegion( Region.getRegion( Regions.US_EAST_1 ) )
     }
@@ -68,8 +59,8 @@ class TestS3IAMConditionKeysForPutObject {
     final ClientConfiguration clientConfiguration = new ClientConfiguration( )
     clientConfiguration.signerOverride = 'S3SignerType'
     final AmazonS3Client s3 = new AmazonS3Client( credentials, clientConfiguration )
-    if ( host ) {
-      s3.setEndpoint( cloudUri( host, '/services/objectstorage' ) )
+    if ( N4j.S3_ENDPOINT ) {
+      s3.setEndpoint( N4j.S3_ENDPOINT )
       s3.setS3ClientOptions( new S3ClientOptions( ).withPathStyleAccess( true ) )
     }
     return s3;

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeysPrefixAndDelimiter.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestS3IAMConditionKeysPrefixAndDelimiter.groovy
@@ -30,7 +30,6 @@ import org.junit.Test
 import java.nio.charset.StandardCharsets
 
 import static N4j.minimalInit
-import static N4j.CLC_IP
 import static N4j.ACCESS_KEY
 import static N4j.SECRET_KEY
 
@@ -49,25 +48,17 @@ import static N4j.SECRET_KEY
  */
 class TestS3IAMConditionKeysPrefixAndDelimiter {
 
-  private final String host
   private final AWSCredentialsProvider credentials
 
   TestS3IAMConditionKeysPrefixAndDelimiter( ) {
     minimalInit()
-    this.host = CLC_IP
     this.credentials = new StaticCredentialsProvider( new BasicAWSCredentials( ACCESS_KEY, SECRET_KEY ) )
-  }
-
-  private String cloudUri( String host, String servicePath ) {
-    URI.create( "http://${host}:8773/" )
-        .resolve( servicePath )
-        .toString( )
   }
 
   private YouAreClient getYouAreClient( final AWSCredentialsProvider credentials  ) {
     final YouAreClient euare = new YouAreClient( credentials )
-    if ( host ) {
-      euare.setEndpoint( cloudUri( host, '/services/Euare' ) )
+    if ( N4j.IAM_ENDPOINT ) {
+      euare.setEndpoint( N4j.IAM_ENDPOINT )
     } else {
       euare.setRegion( Region.getRegion( Regions.US_EAST_1 ) )
     }
@@ -78,8 +69,8 @@ class TestS3IAMConditionKeysPrefixAndDelimiter {
     final ClientConfiguration clientConfiguration = new ClientConfiguration( )
     clientConfiguration.signerOverride = 'S3SignerType'
     final AmazonS3Client s3 = new AmazonS3Client( credentials, clientConfiguration )
-    if ( host ) {
-      s3.setEndpoint( cloudUri( host, '/services/objectstorage' ) )
+    if ( N4j.S3_ENDPOINT ) {
+      s3.setEndpoint( N4j.S3_ENDPOINT )
       s3.setS3ClientOptions( new S3ClientOptions( ).withPathStyleAccess( true ) )
     }
     return s3;

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestSTSAssumeRolePolicy.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestSTSAssumeRolePolicy.groovy
@@ -18,7 +18,6 @@ import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest
 import org.junit.AfterClass
 import org.junit.Test
 
-import static com.eucalyptus.tests.awssdk.N4j.CLC_IP
 import static com.eucalyptus.tests.awssdk.N4j.NAME_PREFIX
 
 /**
@@ -32,7 +31,6 @@ import static com.eucalyptus.tests.awssdk.N4j.NAME_PREFIX
 class TestSTSAssumeRolePolicy {
 
   private final int sleepSecs = 1
-  private final String host
   private final String testAcct
   private final AWSCredentialsProvider adminCredentials
   private final String otherTestAcct
@@ -40,7 +38,6 @@ class TestSTSAssumeRolePolicy {
 
   public TestSTSAssumeRolePolicy( ) {
     N4j.getCloudInfo( )
-    this.host = CLC_IP
     this.testAcct= "${NAME_PREFIX}test-acct"
     N4j.createAccount(testAcct)
     this.adminCredentials = new StaticCredentialsProvider( N4j.getUserCreds(testAcct, 'admin') )
@@ -61,27 +58,21 @@ class TestSTSAssumeRolePolicy {
     N4j.deleteAccount(otherTestAcct)
   }
 
-  private String cloudUri(String servicePath) {
-    URI.create("http://${host}:8773/")
-            .resolve(servicePath)
-            .toString()
-  }
-
   private AWSSecurityTokenService getStsClient(final AWSCredentialsProvider credentials) {
     final AWSSecurityTokenService sts = new AWSSecurityTokenServiceClient(credentials)
-    sts.setEndpoint(cloudUri('/services/Tokens'))
+    sts.setEndpoint(N4j.TOKENS_ENDPOINT)
     sts
   }
 
   private AmazonIdentityManagement getIamClient(final AWSCredentialsProvider credentials) {
     final AmazonIdentityManagement iam = new AmazonIdentityManagementClient(credentials)
-    iam.setEndpoint(cloudUri('/services/Euare'))
+    iam.setEndpoint(N4j.IAM_ENDPOINT)
     iam
   }
 
   private AmazonEC2 getEC2Client(final AWSCredentialsProvider credentials) {
     final AmazonEC2 ec2 = new AmazonEC2Client(credentials)
-    ec2.setEndpoint(cloudUri("/services/compute"))
+    ec2.setEndpoint(N4j.EC2_ENDPOINT)
     ec2
   }
 

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestSTSAssumeRoleWithWebIdentity.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestSTSAssumeRoleWithWebIdentity.groovy
@@ -39,7 +39,6 @@ import org.junit.AfterClass
 import org.junit.Test
 
 import static com.eucalyptus.tests.awssdk.N4j.getCloudInfo
-import static com.eucalyptus.tests.awssdk.N4j.CLC_IP
 import static com.eucalyptus.tests.awssdk.N4j.ACCESS_KEY
 import static com.eucalyptus.tests.awssdk.N4j.SECRET_KEY
 import static com.eucalyptus.tests.awssdk.N4j.NAME_PREFIX
@@ -75,7 +74,6 @@ import java.security.spec.RSAPrivateKeySpec
  */
 class TestSTSAssumeRoleWithWebIdentity {
 
-  private final String host
   private final String path
   private final String domainAndPort
   private final String domain
@@ -152,7 +150,6 @@ class TestSTSAssumeRoleWithWebIdentity {
     this.credentials = new StaticCredentialsProvider( N4j.getUserCreds(testAcct, testUser) )
 
     // configurable / detected values
-    host = CLC_IP
     path = '/pathhere'
     domainAndPort = "s3.${sniffDomain()}:8773".toString( )
     domain = domainAndPort.contains(':') ?
@@ -171,40 +168,34 @@ class TestSTSAssumeRoleWithWebIdentity {
     N4j.deleteAccount(testAcct)
   }
 
-  private String cloudUri(String servicePath) {
-    URI.create("http://${host}:8773/")
-            .resolve(servicePath)
-            .toString()
-  }
-
   private AWSSecurityTokenService getStsClient() {
     final AWSSecurityTokenService sts = new AWSSecurityTokenServiceClient(new AnonymousAWSCredentials())
-    sts.setEndpoint(cloudUri('/services/Tokens'))
+    sts.setEndpoint(N4j.TOKENS_ENDPOINT)
     sts
   }
 
   private AmazonS3 getS3Client(final AWSCredentialsProvider credentials) {
     final AmazonS3 s3 = new AmazonS3Client(credentials, new ClientConfiguration(signerOverride: 'S3SignerType'))
     s3.setS3ClientOptions(new S3ClientOptions(pathStyleAccess: true))
-    s3.setEndpoint(cloudUri("/services/objectstorage"))
+    s3.setEndpoint(N4j.S3_ENDPOINT)
     s3
   }
 
   private AmazonIdentityManagement getIamClient(final AWSCredentialsProvider credentials) {
     final AmazonIdentityManagement iam = new AmazonIdentityManagementClient(credentials)
-    iam.setEndpoint(cloudUri('/services/Euare'))
+    iam.setEndpoint(N4j.IAM_ENDPOINT)
     iam
   }
 
   private AmazonEC2 getEC2Client(final AWSCredentialsProvider credentials) {
     final AmazonEC2 ec2 = new AmazonEC2Client(credentials)
-    ec2.setEndpoint(cloudUri("/services/compute"))
+    ec2.setEndpoint(N4j.EC2_ENDPOINT)
     ec2
   }
 
   private YouProp getYouPropClient(final AWSCredentialsProvider credentials) {
     new YouPropClient(credentials).with {
-      setEndpoint(cloudUri("/services/Properties"))
+      setEndpoint(N4j.PROPERTIES_ENDPOINT)
       it
     }
   }

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestSTSGetAccessToken.java
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestSTSGetAccessToken.java
@@ -19,7 +19,6 @@
  ************************************************************************/
 package com.eucalyptus.tests.awssdk;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -52,7 +51,6 @@ import com.github.sjones4.youcan.youtoken.model.GetAccessTokenResult;
 import org.junit.Test;
 
 import static com.eucalyptus.tests.awssdk.N4j.minimalInit;
-import static com.eucalyptus.tests.awssdk.N4j.CLC_IP;
 import static com.eucalyptus.tests.awssdk.N4j.ACCESS_KEY;
 import static com.eucalyptus.tests.awssdk.N4j.SECRET_KEY;
 
@@ -63,7 +61,6 @@ import static com.eucalyptus.tests.awssdk.N4j.SECRET_KEY;
  */
 public class TestSTSGetAccessToken {
 
-  private final String host;
   private final String accessKey;
   private final String secretKey;
 
@@ -74,20 +71,12 @@ public class TestSTSGetAccessToken {
 
   public TestSTSGetAccessToken( ) throws Exception {
     minimalInit();
-    this.host = CLC_IP;
     this.accessKey = ACCESS_KEY;
     this.secretKey = SECRET_KEY;
   }
 
   private AWSCredentials credentials() {
     return new BasicAWSCredentials( accessKey, secretKey );
-  }
-
-  private String cloudUri( String servicePath ) {
-    return
-        URI.create( "http://" + host + ":8773/" )
-            .resolve( servicePath )
-            .toString();
   }
 
   private AmazonEC2 getEc2ClientUsingToken( final String accountAlias,
@@ -101,7 +90,7 @@ public class TestSTSGetAccessToken {
             userName,
             password.toCharArray()
         ) );
-        sts.setEndpoint( cloudUri( "/services/Tokens" ) );
+        sts.setEndpoint( N4j.TOKENS_ENDPOINT );
         final GetAccessTokenResult sessionTokenResult = sts.getAccessToken();
 
         return new BasicSessionCredentials(
@@ -115,7 +104,7 @@ public class TestSTSGetAccessToken {
       public void refresh() {
       }
     } );
-    ec2.setEndpoint( cloudUri( "/services/Eucalyptus/" ) );
+    ec2.setEndpoint( N4j.EC2_ENDPOINT );
     return ec2;
   }
 
@@ -123,13 +112,13 @@ public class TestSTSGetAccessToken {
     final AmazonEC2 ec2 = new AmazonEC2Client( new BasicAWSCredentials(
         accessKey.getAccessKeyId(),
         accessKey.getSecretAccessKey() ) );
-    ec2.setEndpoint( cloudUri( "/services/Eucalyptus" ) );
+    ec2.setEndpoint( N4j.EC2_ENDPOINT );
     return ec2;
   }
 
   private YouAreClient getYouAreClient( ) {
     final YouAreClient euare = new YouAreClient( credentials( ) );
-    euare.setEndpoint( cloudUri( "/services/Euare" ) );
+    euare.setEndpoint( N4j.IAM_ENDPOINT );
     return euare;
   }
 
@@ -140,7 +129,7 @@ public class TestSTSGetAccessToken {
         request.addParameter( "DelegateAccount", asAccount );
       }
     } );
-    euare.setEndpoint( cloudUri( "/services/Euare" ) );
+    euare.setEndpoint( N4j.IAM_ENDPOINT );
     return euare;
   }
 
@@ -155,7 +144,7 @@ public class TestSTSGetAccessToken {
             userName,
             password.toCharArray()
         ) );
-        sts.setEndpoint( cloudUri( "/services/Tokens" ) );
+        sts.setEndpoint( N4j.TOKENS_ENDPOINT );
         final GetAccessTokenResult sessionTokenResult = sts.getAccessToken();
 
         return new BasicSessionCredentials(
@@ -169,7 +158,7 @@ public class TestSTSGetAccessToken {
       public void refresh() {
       }
     } );
-    euare.setEndpoint( cloudUri( "/services/Euare" ) );
+    euare.setEndpoint( N4j.IAM_ENDPOINT );
     return euare;
   }
 

--- a/src/main/java/com/eucalyptus/tests/awssdk/TestSTSGetImpersonationToken.java
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestSTSGetImpersonationToken.java
@@ -49,9 +49,9 @@ import com.github.sjones4.youcan.youtoken.model.GetImpersonationTokenResult;
 import org.junit.Test;
 
 import static com.eucalyptus.tests.awssdk.N4j.minimalInit;
-import static com.eucalyptus.tests.awssdk.N4j.CLC_IP;
 import static com.eucalyptus.tests.awssdk.N4j.ACCESS_KEY;
 import static com.eucalyptus.tests.awssdk.N4j.SECRET_KEY;
+
 /**
  * This application tests getting an impersonation token using STS and consuming EC2 with the creds.
  *
@@ -59,7 +59,6 @@ import static com.eucalyptus.tests.awssdk.N4j.SECRET_KEY;
  */
 public class TestSTSGetImpersonationToken {
 
-  private final String host;
   private final String accessKey;
   private final String secretKey;
 
@@ -70,7 +69,6 @@ public class TestSTSGetImpersonationToken {
 
   public TestSTSGetImpersonationToken() throws Exception{
     minimalInit();
-    this.host = CLC_IP;
     this.accessKey = ACCESS_KEY;
     this.secretKey = SECRET_KEY;
   }
@@ -79,20 +77,13 @@ public class TestSTSGetImpersonationToken {
     return new BasicAWSCredentials( accessKey, secretKey );
   }
 
-  private String cloudUri( String servicePath ) {
-    return
-        URI.create( "http://" + host + ":8773/" )
-            .resolve( servicePath )
-            .toString();
-  }
-
   private AmazonEC2 getEc2ClientUsingToken( final String accountAlias,
                                             final String userName ) {
     final AmazonEC2 ec2 = new AmazonEC2Client( new AWSCredentialsProvider(){
       @Override
       public AWSCredentials getCredentials() {
         final YouTokenClient tokens = new YouTokenClient( credentials() );
-        tokens.setEndpoint( cloudUri( "/services/Tokens" ) );
+        tokens.setEndpoint( N4j.TOKENS_ENDPOINT );
         final GetImpersonationTokenResult impersonationTokenResult = tokens.getImpersonationToken(
             new GetImpersonationTokenRequest()
                 .withAccountAlias( accountAlias)
@@ -110,13 +101,13 @@ public class TestSTSGetImpersonationToken {
       public void refresh() {
       }
     } );
-    ec2.setEndpoint( cloudUri( "/services/Eucalyptus" ) );
+    ec2.setEndpoint( N4j.EC2_ENDPOINT );
     return ec2;
   }
 
   private YouAreClient getYouAreClient( ) {
     final YouAreClient euare = new YouAreClient( credentials( ) );
-    euare.setEndpoint( cloudUri( "/services/Euare" ) );
+    euare.setEndpoint( N4j.IAM_ENDPOINT );
     return euare;
   }
 
@@ -127,7 +118,7 @@ public class TestSTSGetImpersonationToken {
         request.addParameter( "DelegateAccount", asAccount );
       }
     } );
-    euare.setEndpoint( cloudUri( "/services/Euare" ) );
+    euare.setEndpoint( N4j.IAM_ENDPOINT );
     return euare;
   }
 
@@ -135,7 +126,7 @@ public class TestSTSGetImpersonationToken {
     final AmazonEC2 ec2 = new AmazonEC2Client( new BasicAWSCredentials(
         accessKey.getAccessKeyId(),
         accessKey.getSecretAccessKey() ) );
-    ec2.setEndpoint( cloudUri( "/services/Eucalyptus" ) );
+    ec2.setEndpoint( N4j.EC2_ENDPOINT );
     return ec2;
   }
 


### PR DESCRIPTION
This pull request updates unit tests to use the endpoints from the configuration file rather than deriving from the cloud controller ip address. This then allows use of a local configuration file rather than having to retrieve credentials over ssh.