### PR TITLE
Increase snapshot timeout for EC2 IAM condition key test

### DIFF
--- a/src/main/java/com/eucalyptus/tests/awssdk/TestEC2IAMConditionKeys.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestEC2IAMConditionKeys.groovy
@@ -1365,7 +1365,7 @@ class TestEC2IAMConditionKeys {
       }
 
       print( "Waiting for snapshot to complete ${snapshotId}" )
-      waitForSnapshots( it, TimeUnit.SECONDS.toMillis( 60L ) )
+      waitForSnapshots( it, TimeUnit.MINUTES.toMillis( 5L ) )
     }
 
     AmazonEC2 userEc2 = AmazonEC2Client.builder( )


### PR DESCRIPTION
Test can fail due to too short timeout when creating snapshot.