### PR TITLE
CloudFormation test template for ec2 instance signal resource use

### DIFF
--- a/src/main/java/com/eucalyptus/tests/awssdk/TestCFTemplatesFull.groovy
+++ b/src/main/java/com/eucalyptus/tests/awssdk/TestCFTemplatesFull.groovy
@@ -107,6 +107,14 @@ class TestCFTemplatesFull {
   }
 
   /**
+   * Test for ec2 cfn-signal
+   */
+  @Test
+  void testEc2SignalResourceTemplate( ) {
+    stackCreateDelete( 'ec2_signal_resource', [ ], [ 'ImageId': N4j.IMAGE_ID ] )
+  }
+
+  /**
    * Test basic IAM resources
    */
   @Test

--- a/src/main/resources/com/eucalyptus/tests/awssdk/cf_template_ec2_signal_resource.json
+++ b/src/main/resources/com/eucalyptus/tests/awssdk/cf_template_ec2_signal_resource.json
@@ -1,0 +1,98 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+
+  "Description" : "EC2 template testing resource signal from instance without profile/role",
+
+  "Parameters" : {
+
+    "InstanceType" : {
+      "Description" : "EC2 instance type",
+      "Type" : "String",
+      "Default" : "m1.small",
+      "AllowedValues" : [ "t1.micro", "m1.small", "m1.medium", "m1.large", "m1.xlarge", "m2.xlarge" ],
+      "ConstraintDescription" : "must be a valid EC2 instance type."
+    },
+
+    "ImageId" : {
+      "Description" : "Image identifier",
+      "Type" : "String",
+      "Default" : ""
+    },
+
+    "KeyName": {
+      "Description" : "EC2 keypair for instance SSH access",
+      "Type": "String",
+      "Default": ""
+    },
+
+    "SSHLocation" : {
+      "Description" : " The IP address range that can be used to SSH to the EC2 instances",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "18",
+      "Default": "0.0.0.0/0",
+      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+      "ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x."
+    }
+  },
+
+  "Conditions" : {
+    "UseImageIdParameter" : {"Fn::Not": [{"Fn::Equals" : [{"Ref" : "ImageId"}, ""]}]},
+    "UseKeyNameParameter" : {"Fn::Not": [{"Fn::Equals" : [{"Ref" : "KeyName"}, ""]}]}
+  },
+
+  "Resources" : {
+
+    "Instance": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "ImageId" : { "Fn::If" : [
+          "UseImageIdParameter",
+          { "Ref" : "ImageId" },
+          "emi-00000000"
+        ] },
+        "InstanceType"   : { "Ref" : "InstanceType" },
+        "KeyName"        : { "Fn::If" : [
+          "UseKeyNameParameter",
+          { "Ref" : "KeyName" },
+          { "Ref" : "AWS::NoValue" }
+        ] },
+        "SecurityGroups" : [ {"Ref" : "SecurityGroup"} ],
+        "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [
+          "#!/bin/bash -xe\n",
+          "set -euo pipefail\n",
+          "\n",
+          "# get instance meta-data\n",
+          "META_INSTANCE_ID=\"$(curl -s http://169.254.169.254/latest/meta-data/instance-id)\"\n",
+          "META_ID_DOC=\"$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | base64 -w 0)\"\n",
+          "META_ID_SIG=\"$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/signature | tr '\n' ' ' | sed 's/ //g')\"\n",
+          "\n",
+          "# signal cfn status\n",
+          "curl \\\n",
+          "  --silent \\\n",
+          "  --show-error \\\n",
+          "  --header \"Authorization: CFN_V1 ${META_ID_DOC}:${META_ID_SIG}\" \\\n",
+          "  \"http://cloudformation.internal:8773/?Action=SignalResource&LogicalResourceId=Instance&StackName=",
+          { "Ref" : "AWS::StackName" },
+          "&Status=SUCCESS&UniqueId=${META_INSTANCE_ID}&Version=2010-05-15\"\n",
+          "\n"
+        ]]}}
+      },
+      "CreationPolicy" : {
+        "ResourceSignal" : {
+          "Timeout" : "PT5M"
+        }
+      }
+    },
+
+    "SecurityGroup" : {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties" : {
+        "GroupDescription" : "Enable SSH access",
+        "SecurityGroupIngress" : [
+          {"IpProtocol" : "tcp", "FromPort" : "22", "ToPort" : "22", "CidrIp" : { "Ref" : "SSHLocation"}}
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
The CloudFormation full test suite is updated with a template using signal resource from an ec2 instance.

Corymbia/eucalyptus#82