### PR TITLE
CloudFormation test coverage for elb access logging test file creation

### DIFF
--- a/src/main/java/com/eucalyptus/tests/awssdk/N4j.java
+++ b/src/main/java/com/eucalyptus/tests/awssdk/N4j.java
@@ -523,6 +523,10 @@ public class N4j {
     }
 
     public static AmazonS3 getS3Client(AWSCredentials credentials, String endpoint) {
+        return getS3Client(new AWSStaticCredentialsProvider(credentials), endpoint);
+    }
+
+    public static AmazonS3 getS3Client(AWSCredentialsProvider credentials, String endpoint) {
         final AmazonS3 s3 =
             new AmazonS3Client(credentials, new ClientConfiguration( ).withSignerOverride("S3SignerType"));
         s3.setEndpoint(endpoint);
@@ -1457,12 +1461,13 @@ public class N4j {
     public static synchronized void synchronizedCreateAccount(String accountName) {
         createAccount(accountName);
     }
-    public static void createAccount(String accountName) {
+    public static String createAccount(String accountName) {
         int numAccountsBefore = youAre.listAccounts().getAccounts().size();
         CreateAccountRequest createAccountRequest = new CreateAccountRequest().withAccountName(accountName);
-        youAre.createAccount(createAccountRequest);
+        String accountId = youAre.createAccount(createAccountRequest).getAccount().getAccountId();
         assertThat((numAccountsBefore < youAre.listAccounts().getAccounts().size()),"Failed to create account " + accountName);
-        print("Created account: " + accountName);
+        print("Created account: " + accountName + " [" + accountId + "]");
+        return accountId;
     }
 
     public static synchronized void synchronizedDeleteAccount(String accountName) {

--- a/src/main/resources/com/eucalyptus/tests/awssdk/cf_template_trinity.json
+++ b/src/main/resources/com/eucalyptus/tests/awssdk/cf_template_trinity.json
@@ -4,6 +4,11 @@
   "Description" : "Load balanced and auto scaled web site. Auto-scaled based on the CPU utilization of the web servers. Instances are load balanced with a simple health check against the default web page.",
 
   "Parameters" : {
+    "ElbAccountId" : {
+      "Description" : "Elastic load balancing account id for the region",
+      "Type" : "String"
+    },
+
     "InstanceType" : {
       "Description" : "WebServer EC2 instance type",
       "Type" : "String",
@@ -31,6 +36,29 @@
   },
 
   "Resources" : {
+    "Bucket": {
+      "Type": "AWS::S3::Bucket"
+    },
+
+    "BucketPolicy": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {"Ref": "Bucket"},
+        "PolicyDocument": {
+          "Version": "2008-10-17",
+          "Statement": [ {
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [ "", [ "arn:aws:s3:::", { "Ref": "Bucket" }, "/AWSLogs/", { "Ref": "AWS::AccountId" }, "/*" ] ]
+              },
+              "Principal": { "AWS": { "Ref": "ElbAccountId" } },
+              "Action": [ "s3:PutObject" ]
+            }
+          ]
+        }
+      }
+    },
+
     "WebServerGroup" : {
       "Type" : "AWS::AutoScaling::AutoScalingGroup",
       "Properties" : {
@@ -140,7 +168,13 @@
 
     "ElasticLoadBalancer" : {
       "Type" : "AWS::ElasticLoadBalancing::LoadBalancer",
+      "DependsOn": "BucketPolicy",
       "Properties" : {
+        "AccessLoggingPolicy" : {
+          "EmitInterval" : 60,
+          "Enabled" : true,
+          "S3BucketName" : { "Ref" : "Bucket" }
+        },
         "AvailabilityZones" : { "Fn::GetAZs" : "" },
         "CrossZone" : "true",
         "HealthCheck" : {
@@ -196,6 +230,10 @@
     "WebServerGroupName" : {
       "Description" : "Name of the web server Auto Scaling Group",
       "Value" :  { "Ref": "WebServerGroup" }
+    },
+    "BucketName": {
+      "Description" : "Name of the bucket used for ELB access logs",
+      "Value" :  { "Ref": "Bucket" }
     }
   }
 }


### PR DESCRIPTION
Update cloudformation trinity (as/cw/elb) test to use access logging and verify creation of test file.

Corymbia/eucalyptus#92